### PR TITLE
backend/fix: move user ID to params in update route

### DIFF
--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -10,7 +10,7 @@ router.post("/users", (request, response, next) => {
 });
 
 // PUT route to update a user
-router.put("/users", (request, response, next) => {
+router.put("/users/:id", (request, response, next) => {
 	return updateUserController.handle(request, response, next);
 });
 

--- a/backend/src/useCases/User/UpdateUser/UpdateUserController.ts
+++ b/backend/src/useCases/User/UpdateUser/UpdateUserController.ts
@@ -11,8 +11,11 @@ export class UpdateUserController {
 		response: Response,
 		next: NextFunction
 	): Promise<Response<ApiResponse<IUpdateUserResponseDTO>>> {
+		// Get the id from the URL params
+		const { id } = request.params;
+
 		// Extract user data from the request body
-		const { id, name, email, password } = request.body;
+		const { name, email, password } = request.body;
 
 		try {
 			// Execute the use case to update an existing user


### PR DESCRIPTION
- Changed the update route to include the user ID in the URL parameter: PUT /users/:id
- Updated the controller to retrieve the ID from URL params instead of the body
- Aligned with RESTful best practices for resource identification